### PR TITLE
Accept arbitrary selections

### DIFF
--- a/coloraf.py
+++ b/coloraf.py
@@ -1,7 +1,7 @@
 from pymol import cmd
 
 
-def coloraf(protein):
+def coloraf(selection="all"):
 
     """
     AUTHOR
@@ -11,18 +11,18 @@ def coloraf(protein):
     Colors Alphafold structures by pLDDT
 
     USAGE
-    coloraf protein
+    coloraf sele
 
     PARAMETERS
 
-    protein (string)
-    The name of the selection/object to color by pLDDT
+    sele (string)
+    The name of the selection/object to color by pLDDT. Default: all
     """
 
-    cmd.color("blue", f"m. {protein} and b > 90")
-    cmd.color("cyan", f"m. {protein} and b < 90 and b > 70")
-    cmd.color("yellow", f"m. {protein} and b < 70 and b > 50")
-    cmd.color("orange", f"m. {protein} and b < 50")
+    cmd.color("blue", f"({selection}) and b > 90")
+    cmd.color("cyan", f"({selection}) and b < 90 and b > 70")
+    cmd.color("yellow", f"({selection}) and b < 70 and b > 50")
+    cmd.color("orange", f"({selection}) and b < 50")
 
 
 cmd.extend("coloraf", coloraf)


### PR DESCRIPTION
Allows coloraf to accept arbitrary selections rather than only models. Models valid selections, so the previous behavior still works.

The selection defaults to 'all' so the command can be used quickly without arguments.