### PR TITLE
Update coloraf.py

### DIFF
--- a/coloraf.py
+++ b/coloraf.py
@@ -27,10 +27,10 @@ def AFcolors(selection="all"):
     The name of the selection/object to color by pLDDT. Default: all
     """
 
-    cmd.color("0x126DFF", f"({selection}) and (b > 90 or b = 90)")
-    cmd.color("0x0ECFF1", f"({selection}) and ((b < 90 and b > 70) or b = 70)")
-    cmd.color("0xF6ED12", f"({selection}) and ((b < 70 and b > 50) or b = 50)")
-    cmd.color("0xEE831D", f"({selection}) and b < 50")
+    cmd.color("0x0053D6", f"({selection}) and (b > 90 or b = 90)")
+    cmd.color("0x64CBF3", f"({selection}) and ((b < 90 and b > 70) or b = 70)")
+    cmd.color("0xFFDB13", f"({selection}) and ((b < 70 and b > 50) or b = 50)")
+    cmd.color("0xFE7D45", f"({selection}) and b < 50")
 
 
 cmd.extend("AFcolors", AFcolors)

--- a/coloraf.py
+++ b/coloraf.py
@@ -1,17 +1,25 @@
 from pymol import cmd
 
 
-def coloraf(selection="all"):
+def AFcolors(selection="all"):
 
     """
     AUTHOR
-    Christian Balbin
-
+    Christian Balbin 
+    
+    ADAPTATION
+    Nicolas-Frederic Lipp
+    
     DESCRIPTION
     Colors Alphafold structures by pLDDT
+    An improved version of the original
+    Prevent exact values of 90, 70, and 50 from not being recolored.
+    Ranges were checked on AFDB to ensure that 90, 70, and 50 match their color scheme, despite the nonsensical model confidence legend available on AFDB website.
+    The colors now match exactly AFDB color scheme
+    Replace 'coloraf' by 'AFcolors'
 
     USAGE
-    coloraf sele
+    AFcolors sele
 
     PARAMETERS
 
@@ -19,11 +27,11 @@ def coloraf(selection="all"):
     The name of the selection/object to color by pLDDT. Default: all
     """
 
-    cmd.color("blue", f"({selection}) and b > 90")
-    cmd.color("cyan", f"({selection}) and b < 90 and b > 70")
-    cmd.color("yellow", f"({selection}) and b < 70 and b > 50")
-    cmd.color("orange", f"({selection}) and b < 50")
+    cmd.color("0x126DFF", f"({selection}) and (b > 90 or b = 90)")
+    cmd.color("0x0ECFF1", f"({selection}) and ((b < 90 and b > 70) or b = 70)")
+    cmd.color("0xF6ED12", f"({selection}) and ((b < 70 and b > 50) or b = 50)")
+    cmd.color("0xEE831D", f"({selection}) and b < 50")
 
 
-cmd.extend("coloraf", coloraf)
-cmd.auto_arg[0]["coloraf"] = [cmd.object_sc, "object", ""]
+cmd.extend("AFcolors", AFcolors)
+cmd.auto_arg[0]["AFcolors"] = [cmd.object_sc, "object", ""]


### PR DESCRIPTION
An updated version for more reliability
    An improved version of the original
    Prevent exact values of 90, 70, and 50 from not being recolored.
    Ranges were checked on AFDB to ensure that 90, 70, and 50 match their color scheme, despite the nonsensical model confidence legend available on AFDB website.
    The colors now match exactly AFDB color scheme
    Replace 'coloraf' by 'AFcolors'